### PR TITLE
vrpy 0.5.1 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,5 +2,5 @@ upload_channels:
   - sfe1ed40
 
 channels:
-  - https://staging.continuum.io/prefect/fs/cspy-feedstock/pr1/b0e6abc
-  - https://staging.continuum.io/prefect/fs/lemon-feedstock/pr1/85a724d
+  - https://staging.continuum.io/prefect/fs/cspy-feedstock/pr1/b310efb
+  - https://staging.continuum.io/prefect/fs/lemon-feedstock/pr1/5894d1a

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+  - https://staging.continuum.io/prefect/fs/cspy-feedstock/pr1/4970fbd
+  - https://staging.continuum.io/prefect/fs/lemon-feedstock/pr1/4a68186

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ upload_channels:
   - sfe1ed40
 
 channels:
-  - https://staging.continuum.io/prefect/fs/cspy-feedstock/pr1/cf147df
+  - https://staging.continuum.io/prefect/fs/cspy-feedstock/pr1/44c7504

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,5 +2,5 @@ upload_channels:
   - sfe1ed40
 
 channels:
-  - https://staging.continuum.io/prefect/fs/cspy-feedstock/pr1/b310efb
+  - https://staging.continuum.io/prefect/fs/cspy-feedstock/pr1/ced8a77
   - https://staging.continuum.io/prefect/fs/lemon-feedstock/pr1/5894d1a

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,5 +2,4 @@ upload_channels:
   - sfe1ed40
 
 channels:
-  - https://staging.continuum.io/prefect/fs/cspy-feedstock/pr1/ced8a77
-  - https://staging.continuum.io/prefect/fs/lemon-feedstock/pr1/5894d1a
+  - https://staging.continuum.io/prefect/fs/cspy-feedstock/pr1/cf147df

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,5 +2,5 @@ upload_channels:
   - sfe1ed40
 
 channels:
-  - https://staging.continuum.io/prefect/fs/cspy-feedstock/pr1/4970fbd
-  - https://staging.continuum.io/prefect/fs/lemon-feedstock/pr1/4a68186
+  - https://staging.continuum.io/prefect/fs/cspy-feedstock/pr1/b0e6abc
+  - https://staging.continuum.io/prefect/fs/lemon-feedstock/pr1/85a724d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "vrpy" %}
+{% set version = "0.5.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # switch to GH release archive because LICENSE and tests
+  url: https://github.com/Kuifje02/vrpy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 36e86aac1b9cf5efc13fd5f961ecc93a04b4a8b12ed5e08a187c0b3ccaa08b85
+  patches:
+    - patches/0001-fix-readme-and-version.patch
+    - patches/0002-fix-from_numpy_matrix-to-from_numpy_array.patch
+
+build:
+  number: 0
+  # pulp not available py312
+  skip: true  # [py==312]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  build:
+    - patch     # [not win]
+    - m2-patch  # [win]
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python
+    - cspy
+    - networkx
+    - numpy
+    - pulp
+    - coin-or-cbc
+
+test:
+  imports:
+    - vrpy
+  requires:
+    - pip
+    - pytest
+  source_files:
+    - tests
+  commands:
+    - pip check
+    - pytest -v tests
+
+about:
+  home: https://github.com/Kuifje02/vrpy
+  license: MIT
+  license_file: LICENSE
+  license_family: MIT
+  summary: A python framework for solving vehicle routing problems
+  description: |
+    A python framework for solving vehicle routing problems
+  doc_url: https://vrpy.readthedocs.io
+  dev_url: https://github.com/Kuifje02/vrpy
+
+extra:
+  recipe-maintainers:
+    - lorepirri

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,8 +15,8 @@ source:
 
 build:
   number: 0
-  # pulp not available py312
-  skip: true  # [py==312]
+  # pulp not available for s390x or py312
+  skip: true  # [s390x or py==312]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ requirements:
     - networkx
     - numpy
     - pulp
-    - coin-or-cbc
 
 test:
   imports:
@@ -46,7 +45,8 @@ test:
     - tests
   commands:
     - pip check
-    - pytest -v tests
+    # ignore/skip tests that require the default solver PULP_CBC_CMD from pulp
+    - pytest -v --ignore=tests/test_toy.py -k "not (test_solve or test_node_load)"
 
 about:
   home: https://github.com/Kuifje02/vrpy

--- a/recipe/patches/0001-fix-readme-and-version.patch
+++ b/recipe/patches/0001-fix-readme-and-version.patch
@@ -1,0 +1,32 @@
+From 9ef158ff2f858b818d039db52d59ada9b65d33eb Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Tue, 16 Jul 2024 16:48:11 +0200
+Subject: [PATCH 1/2] fix readme and version
+
+---
+ setup.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 4d8d6ee..ea56c83 100644
+--- a/setup.py
++++ b/setup.py
+@@ -2,13 +2,13 @@ import setuptools
+ 
+ setuptools.setup(
+     name="vrpy",
+-    version="0.5.0",
++    version="0.5.1",
+     description="A python framework for solving vehicle routing problems",
+     license="MIT",
+     author="Romain Montagne, David Torres",
+     author_email="r.montagne@hotmail.fr",
+     keywords=["vehicle routing problem", "vrp", "column generation"],
+-    long_description=open("README.rst", "r").read(),
++    long_description=open("README.md", "r", encoding="UTF-8").read(),
+     long_description_content_type="text/x-rst",
+     url="https://github.com/Kuifje02/vrpy",
+     packages=setuptools.find_packages(),
+-- 
+2.39.1
+

--- a/recipe/patches/0002-fix-from_numpy_matrix-to-from_numpy_array.patch
+++ b/recipe/patches/0002-fix-from_numpy_matrix-to-from_numpy_array.patch
@@ -1,0 +1,31 @@
+From 8ae7e5e0dc31407fc3995e567cc974a92f92dfa3 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Tue, 16 Jul 2024 17:21:37 +0200
+Subject: [PATCH 2/2] fix from_numpy_matrix to from_numpy_array
+
+---
+ tests/test_issue99.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/test_issue99.py b/tests/test_issue99.py
+index 3736134..71a4caf 100644
+--- a/tests/test_issue99.py
++++ b/tests/test_issue99.py
+@@ -1,4 +1,4 @@
+-from networkx import from_numpy_matrix, set_node_attributes, relabel_nodes, DiGraph
++from networkx import from_numpy_array, set_node_attributes, relabel_nodes, DiGraph
+ from numpy import array
+ from vrpy import VehicleRoutingProblem
+ 
+@@ -236,7 +236,7 @@ class TestIssue79:
+ 
+         # Transform distance matrix to DiGraph
+         A_ = array(distance_, dtype=[("cost", int)])
+-        G_ = from_numpy_matrix(A_, create_using=DiGraph())
++        G_ = from_numpy_array(A_, create_using=DiGraph())
+ 
+         # Set demand
+         set_node_attributes(G_, values=demands, name="demand")
+-- 
+2.39.1
+


### PR DESCRIPTION
vrpy 0.5.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4791]
- dev_url (pypi): https://github.com/Kuifje02/vrpy
- conda-forge: _feedstock not found on conda-forge_
- pypi: https://pypi.org/project/vrpy/0.5.1
- pypi inspector: https://inspector.pypi.io/project/vrpy/0.5.1

### Explanation of changes:

- new feedstock
- patch for readme `utf-8` (and the version they forgot to update it)
- patch to fix an import for an old version of `networkx`
- skip all the tests that use the `solve` method because it uses the default solver from `pulp` which is not available

### Depends on

- AnacondaRecipes/cspy-feedstock#1

### Notes for the Reviewers

- The default solver for `pulp` is unavailable in the package `pulp` in our `defaults` channel. Therefore the package `vrpy` is useless unless one of the two other solvers is installed (`gurobi`, `cplex `). See: https://vrpy.readthedocs.io/en/latest/solving_options.html
- See also this discussion: https://anaconda.slack.com/archives/C02K52E033M/p1721238331333339

[PKG-4791]: https://anaconda.atlassian.net/browse/PKG-4791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ