### PR TITLE
vrpy 0.5.1 [fix: remove staging channel, bump build number]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/prefect/fs/cspy-feedstock/pr1/44c7504

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - patches/0002-fix-from_numpy_matrix-to-from_numpy_array.patch
 
 build:
-  number: 0
+  number: 1
   # pulp not available for s390x or py312
   skip: true  # [s390x or py==312]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv


### PR DESCRIPTION
vrpy 0.5.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4791]
- ref: AnacondaRecipes/vrpy-feedstock#1

### Explanation of changes:

- mistakenly left the staging channel: removed, bumped the build number


[PKG-4791]: https://anaconda.atlassian.net/browse/PKG-4791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ